### PR TITLE
Updated to Lume 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.0] - Unreleased
+Updated to Lume 3.
+
 ## [0.3.2] - 2025-04-19
 Move items to `src`
 
@@ -22,7 +25,8 @@ Add initial look for the page
 ## [0.1.0] - 2025-04-18
 Initial barebones from boilerplate
 
-[0.3.2]: https://github.com/wewillcraft/pro-file/compare/v0.3.1...HEAD
+[0.4.0]: https://github.com/wewillcraft/pro-file/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/wewillcraft/pro-file/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/wewillcraft/pro-file/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/wewillcraft/pro-file/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/wewillcraft/pro-file/compare/v0.1.0...v0.2.0

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v2.5.3/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.3/",
-    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.8/jsx-runtime.ts"
+    "lume/": "https://deno.land/x/lume@v3.0.0/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
+    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.9/jsx-runtime.ts"
   },
   "lock": false,
   "tasks": {
@@ -16,10 +16,21 @@
     }
   },
   "compilerOptions": {
-    "types": ["lume/types.ts"],
+    "types": [
+      "lume/types.ts"
+    ],
     "jsx": "react-jsx",
     "jsxImportSource": "lume"
   },
-  "exclude": ["./_site"],
-  "unstable": ["temporal"]
+  "exclude": [
+    "./_site"
+  ],
+  "unstable": [
+    "temporal"
+  ],
+  "lint": {
+    "plugins": [
+      "https://deno.land/x/lume@v3.0.0/lint.ts"
+    ]
+  }
 }

--- a/plugins.ts
+++ b/plugins.ts
@@ -1,9 +1,6 @@
-import lightningcss from "lume/plugins/lightningcss.ts";
 import tailwindcss from "lume/plugins/tailwindcss.ts";
 import inline from "lume/plugins/inline.ts";
 import icons from "lume/plugins/icons.ts";
-import typography from "npm:@tailwindcss/typography";
-import postcss from "lume/plugins/postcss.ts";
 import basePath from "lume/plugins/base_path.ts";
 import metas from "lume/plugins/metas.ts";
 import { Options as SitemapOptions, sitemap } from "lume/plugins/sitemap.ts";
@@ -28,18 +25,13 @@ export default function (userOptions?: Options) {
   const options = merge(defaults, userOptions);
 
   return (site: Lume.Site) => {
-    site.use(lightningcss())
-      .use(basePath())
+    site.use(basePath())
       .use(metas())
       .use(icons())
+      .use(tailwindcss())
       .use(inline())
       .use(sitemap(options.sitemap))
       .use(favicon(options.favicon))
-      .use(tailwindcss({
-        options: {
-          plugins: [typography],
-        },
-      }))
-      .use(postcss());
+      .add("style.css");
   };
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,2 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";


### PR DESCRIPTION
Hi there!
Lume 3 [was released yesterday](https://lume.land/blog/posts/lume-3/) and all themes not supporting the new version were disabled temporately.

This PR updates the theme to support Lume 3:

- Updated the dependencies in the import map
- Updated Tailwindcss to v4
- Removed unneeded plugins (tailwind no longer depends on postcss, and lightningcss is not necessary because tailwind 4 uses it internally).

Once these changes are merged and a new version is published, I'll re-enable the plugin again.
Thanks!